### PR TITLE
feat: v2.3.1 - 端点协议类型选择 & 上游错误中文化

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,6 +82,7 @@ class ProviderConfig(BaseModel):
     display_name: str = ""     # 看板分组显示名称（空=使用 name）
     capabilities: Dict[str, bool] = {}  # 能力声明: {"t2i": True, "i2i": True, "i2v": False}
     skip_proxy: bool = False   # 跳过全局代理（直连）
+    endpoint_type: str = "auto"  # 端点协议类型: auto|openai|gemini|qwen|agnes|volc_ark_plan|volc_ark
     extra: Dict[str, Any] = {} # 扩展参数
 
     def get_effective_keys(self) -> List[str]:

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ from config import (
     cfg_mgr, GALLERY_DIR, STORAGE_DIR, ProviderConfig, ProvidersConfig,
     is_prod_mode, get_admin_key, verify_admin_key, generate_admin_key, reset_admin_key,
 )
-from providers import generate_multi, enhance_prompt_with_llm, enhance_prompt_with_llm_detailed, ImageResult, fetch_models_from_upstream, _save_image
+from providers import generate_multi, enhance_prompt_with_llm, enhance_prompt_with_llm_detailed, ImageResult, fetch_models_from_upstream, _save_image, translate_upstream_error
 
 
 # ──────────────────────────────────────────────────────────────
@@ -150,6 +150,8 @@ class ProviderCreateReq(BaseModel):
     color: str = "#0ea5e9"
     display_name: str = ""
     capabilities: Dict[str, bool] = {}  # 能力声明: {"t2i": True, "i2i": True}
+    skip_proxy: bool = False            # 跳过全局代理（直连）
+    endpoint_type: str = "auto"         # 端点协议类型
     extra: dict = {}
 
 
@@ -620,18 +622,24 @@ async def fetch_models(provider_id: str):
             try:
                 models = await fetch_models_from_upstream(p)
                 is_fallback = False
-                # 检查是否是 fallback（通过对比已知 fallback 列表）
-                fallback_signatures = {
-                    "gemini": ["gemini-2.0-flash-exp-image-generation", "gemini-1.5-pro", "gemini-1.5-flash"],
-                    "qwen": ["qwen3.6-plus", "wanx-v1", "wanx2.1-t2i-turbo"],
-                    "openai": ["gpt-image-2", "dall-e-3", "flux-dev", "sd-xl"],
-                }
-                protocol = "gemini" if "gemini" in p.base_url.lower() or "google" in p.base_url.lower() else ("qwen" if "qwen" in p.id else "openai")
-                sig_models = fallback_signatures.get(protocol, [])
-                if protocol == "qwen":
-                    is_fallback = len(models) <= 8 and any(m in models for m in sig_models)
-                elif len(models) <= 8 and any(m in models for m in sig_models):
+                note = ""
+                # 火山方舟 Agent Plan：返回的是官方候选名，并非实时拉取
+                if (p.endpoint_type or "auto").strip().lower() == "volc_ark_plan":
                     is_fallback = True
+                    note = "（Agent Plan 无模型列表 API，以上为官方候选模型，真实可用性需在生成时验证；Small 套餐不支持视频生成）"
+                else:
+                    # 检查是否是 fallback（通过对比已知 fallback 列表）
+                    fallback_signatures = {
+                        "gemini": ["gemini-2.0-flash-exp-image-generation", "gemini-1.5-pro", "gemini-1.5-flash"],
+                        "qwen": ["qwen3.6-plus", "wanx-v1", "wanx2.1-t2i-turbo"],
+                        "openai": ["gpt-image-2", "dall-e-3", "flux-dev", "sd-xl"],
+                    }
+                    protocol = "gemini" if "gemini" in p.base_url.lower() or "google" in p.base_url.lower() else ("qwen" if "qwen" in p.id else "openai")
+                    sig_models = fallback_signatures.get(protocol, [])
+                    if protocol == "qwen":
+                        is_fallback = len(models) <= 8 and any(m in models for m in sig_models)
+                    elif len(models) <= 8 and any(m in models for m in sig_models):
+                        is_fallback = True
 
                 # 自动保存到配置中
                 p.models = models
@@ -644,7 +652,7 @@ async def fetch_models(provider_id: str):
                     "count": len(models),
                     "auto_selected": p.model,
                     "is_fallback": is_fallback,
-                    "message": "(使用推荐列表，上游 API 未响应)" if is_fallback else "",
+                    "message": note if is_fallback else "",
                     "provider_type": p.type,
                 }
             except Exception as e:
@@ -1666,13 +1674,28 @@ class VideoGenerateRequest(BaseModel):
 
 
 def _detect_video_provider_type(provider):
-    """检测视频 Provider 的 API 协议类型: 'agnes' | 'gemini' | 'openai'"""
+    """检测视频 Provider 的 API 协议类型: 'agnes' | 'gemini' | 'volcengine' | 'openai'
+
+    优先使用用户显式设置的 endpoint_type；为 auto 时回退到 URL/ID 启发式。
+    """
+    et = (getattr(provider, 'endpoint_type', None) or 'auto').strip().lower()
+    if et in ("volc_ark_plan", "volc_ark", "volcengine"):
+        return "volcengine"
+    if et == "openai":
+        return "openai"
+    if et == "gemini":
+        return "gemini"
+    if et == "agnes":
+        return "agnes"
+
     base = provider.base_url.lower()
     pid = provider.id.lower()
     if "agnes" in pid or "agnes" in base:
         return "agnes"
     if "gemini" in pid or "localhost:38000" in base or "google" in base or "flow2api" in base:
         return "gemini"
+    if "volcengine" in pid or "volces.com" in base or "ark.cn-beijing" in base:
+        return "volcengine"
     return "openai"
 
 
@@ -1705,6 +1728,76 @@ def _build_agnes_payload(req, effective_model):
         # 无图的关键帧模式（罕见）
         payload["extra_body"] = {"mode": "keyframes"}
 
+    return payload
+
+
+def _volcengine_task_base(base_url: str) -> str:
+    """规范化火山方舟视频任务的基础 URL（返回到 .../tasks 之前的前缀）
+
+    支持用户填写多种形式的 Base URL：
+    - https://ark.cn-beijing.volces.com                         → 追加 /api/v3/contents/generations
+    - https://ark.cn-beijing.volces.com/api/v3                  → 追加 /contents/generations
+    - https://ark.cn-beijing.volces.com/api/plan/v3             → 追加 /contents/generations
+    - https://ark.cn-beijing.volces.com/api/plan/v3/contents/generations/tasks → 去掉末尾 /tasks
+    返回值不含末尾的 /tasks，方便统一拼接创建/查询路径。
+    """
+    b = (base_url or "").rstrip("/")
+    # 去掉末尾的 /tasks（用户填了完整任务路径）
+    if b.endswith("/contents/generations/tasks"):
+        return b[:-len("/tasks")]
+    # 已经到 /contents/generations
+    if b.endswith("/contents/generations"):
+        return b
+    # 形如 /api/v3 或 /api/plan/v3
+    if b.endswith("/v3") or "/v3" in b.split("//")[-1]:
+        # 截断到 .../v3
+        idx = b.rfind("/v3")
+        prefix = b[:idx + len("/v3")]
+        return prefix + "/contents/generations"
+    # 裸域名或其他：默认使用标准 /api/v3
+    return b + "/api/v3/contents/generations"
+
+
+def _build_volcengine_payload(req, effective_model):
+    """构建火山方舟 Agent Plan 视频生成请求体"""
+    # 构建 content 数组
+    content = []
+    
+    # 文本提示词
+    prompt_text = req.prompt
+    # 在提示词中追加参数
+    params = []
+    if req.width and req.height:
+        # 计算宽高比
+        from math import gcd
+        w, h = req.width, req.height
+        g = gcd(w, h)
+        ratio = f"{w//g}:{h//g}"
+        params.append(f"--ratio {ratio}")
+    if req.num_frames and req.frame_rate:
+        duration = int(req.num_frames / req.frame_rate)
+        params.append(f"--duration {duration}")
+    if params:
+        prompt_text += " " + " ".join(params)
+    
+    content.append({
+        "type": "text",
+        "text": prompt_text
+    })
+    
+    # 图片输入（图生视频）
+    if req.image:
+        for img_url in req.image:
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": img_url}
+            })
+    
+    payload = {
+        "model": effective_model,
+        "content": content,
+    }
+    
     return payload
 
 
@@ -1904,6 +1997,11 @@ async def video_generate(req: VideoGenerateRequest):
         payload = _build_gemini_payload(req, effective_model)
         api_url = f"{base_url}/chat/completions"
         headers = {"Authorization": f"Bearer {provider.api_key}", "Content-Type": "application/json"}
+    elif provider_type == "volcengine":
+        payload = _build_volcengine_payload(req, effective_model)
+        # Agent Plan / 标准 Ark 均使用 .../contents/generations/tasks 端点
+        api_url = f"{_volcengine_task_base(provider.base_url)}/tasks"
+        headers = {"Authorization": f"Bearer {provider.api_key}", "Content-Type": "application/json"}
     else:
         payload = _build_agnes_payload(req, effective_model)
         api_url = f"{base_url}/videos"
@@ -1939,7 +2037,7 @@ async def video_generate(req: VideoGenerateRequest):
                                 sse_data = _json.loads(data_str)
                                 err = sse_data.get("error")
                                 if err:
-                                    sse_error_msg = err.get("message", str(err))
+                                    sse_error_msg = translate_upstream_error(err.get("message", str(err)))
                                     done_received = True
                                     break
                                 choices = sse_data.get("choices", [])
@@ -1964,9 +2062,9 @@ async def video_generate(req: VideoGenerateRequest):
                             if url_match:
                                 video_result_url = url_match.group(0)
         except _httpx.HTTPStatusError as e:
-            raise HTTPException(status_code=e.response.status_code, detail=f"视频 API 错误: {e.response.text[:500]}")
+            raise HTTPException(status_code=e.response.status_code, detail=f"视频 API 错误: {translate_upstream_error(e.response.text[:500])}")
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"视频 API 调用失败: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"视频 API 调用失败: {translate_upstream_error(str(e))}")
 
         task_id = str(uuid.uuid4())
         video_id = task_id  # Gemini uses task_id as video_id
@@ -1979,6 +2077,24 @@ async def video_generate(req: VideoGenerateRequest):
         else:
             initial_status = "queued"
             initial_progress = 0
+    elif provider_type == "volcengine":
+        # 火山方舟 Agent Plan: 异步任务模式
+        try:
+            async with _httpx.AsyncClient(timeout=180.0) as client:
+                resp = await client.post(api_url, headers=headers, json=payload)
+                resp.raise_for_status()
+                data = resp.json()
+        except _httpx.HTTPStatusError as e:
+            raise HTTPException(status_code=e.response.status_code, detail=f"火山方舟 API 错误: {translate_upstream_error(e.response.text[:500])}")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"火山方舟 API 调用失败: {translate_upstream_error(str(e))}")
+        
+        # 返回格式: {"id": "cgt-xxx", "status": "queued", ...}
+        task_id = data.get("id") or str(uuid.uuid4())
+        video_id = ""
+        video_result_url = ""
+        initial_status = data.get("status", "queued")
+        initial_progress = 0
     else:
         payload = _build_agnes_payload(req, effective_model)
         api_url = f"{base_url}/videos"
@@ -1988,9 +2104,9 @@ async def video_generate(req: VideoGenerateRequest):
                 resp.raise_for_status()
                 data = resp.json()
         except _httpx.HTTPStatusError as e:
-            raise HTTPException(status_code=e.response.status_code, detail=f"视频 API 错误: {e.response.text[:500]}")
+            raise HTTPException(status_code=e.response.status_code, detail=f"视频 API 错误: {translate_upstream_error(e.response.text[:500])}")
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"视频 API 调用失败: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"视频 API 调用失败: {translate_upstream_error(str(e))}")
         task_id = data.get("task_id") or data.get("id") or str(uuid.uuid4())
         video_id = data.get("video_id", "")
         video_result_url = ""
@@ -2053,6 +2169,84 @@ async def video_generate(req: VideoGenerateRequest):
         task_info["error"] = error_detail
         _save_video_history_entry(task_info)
         print(f"[Video] Gemini 视频生成失败: {error_detail} (model={effective_model})")
+    elif provider_type == "volcengine":
+        # ── 火山方舟: 后台轮询线程 ──
+        def _poll_volcengine(tid, base, key, model, prompt_text, provider_id):
+            import time as _t
+            import requests as _req
+            poll_count = 0
+            max_polls = 180  # 最多轮询 180 次 (约 15 分钟)
+            # 构建轮询 URL（base 已是规范化到 .../contents/generations 的前缀）
+            poll_url = f"{base}/tasks/{tid}"
+            while poll_count < max_polls:
+                _t.sleep(15)  # 火山方舟建议 15 秒轮询间隔
+                poll_count += 1
+                try:
+                    r = _req.get(poll_url, headers={"Authorization": f"Bearer {key}"}, timeout=30)
+                    if r.status_code != 200:
+                        print(f"[Video] 火山方舟轮询失败: {r.status_code} {r.text[:200]}")
+                        continue
+                    result = r.json()
+                    status = result.get("status", "")
+                    # 更新进度
+                    if tid in video_tasks:
+                        video_tasks[tid]["status"] = status
+                        # 简单估算进度
+                        if status == "queued":
+                            video_tasks[tid]["progress"] = 10
+                        elif status == "running":
+                            video_tasks[tid]["progress"] = 50
+                    
+                    if status == "succeeded":
+                        # 提取视频 URL
+                        content = result.get("content", {})
+                        vurl = content.get("video_url", "") if isinstance(content, dict) else ""
+                        if tid in video_tasks:
+                            video_tasks[tid]["video_url"] = vurl
+                            video_tasks[tid]["progress"] = 100
+                            video_tasks[tid]["status"] = "completed"
+                        # 下载视频
+                        if vurl:
+                            try:
+                                vr = _req.get(vurl, timeout=120)
+                                if vr.status_code == 200:
+                                    ts2 = time.strftime("%Y%m%d_%H%M%S")
+                                    safe_p = "".join(c if c.isalnum() else "_" for c in prompt_text[:30])
+                                    vfn = f"{provider_id}_{ts2}_{safe_p}_{uuid.uuid4().hex[:6]}.mp4"
+                                    vp = VIDEO_DIR / vfn
+                                    vp.write_bytes(vr.content)
+                                    _generate_video_thumbnail_async(vp)
+                                    if tid in video_tasks:
+                                        video_tasks[tid]["local_path"] = str(vp)
+                            except Exception as e:
+                                print(f"[Video] 火山方舟视频下载失败: {e}")
+                        if tid in video_tasks:
+                            _save_video_history_entry(video_tasks[tid])
+                        return
+                    elif status in ("failed", "expired"):
+                        error_msg = translate_upstream_error(result.get("error", {}).get("message", "任务失败") if isinstance(result.get("error"), dict) else str(result.get("error", "任务失败")))
+                        if tid in video_tasks:
+                            video_tasks[tid]["status"] = "failed"
+                            video_tasks[tid]["error"] = error_msg
+                            _save_video_history_entry(video_tasks[tid])
+                        print(f"[Video] 火山方舟视频生成失败: {error_msg} (model={model})")
+                        return
+                    # queued/running 继续轮询
+                except Exception as e:
+                    print(f"[Video] 火山方舟轮询异常: {e}")
+                    continue
+            # 超时
+            if tid in video_tasks:
+                video_tasks[tid]["status"] = "timeout"
+                video_tasks[tid]["error"] = "任务超时（超过 15 分钟）"
+                _save_video_history_entry(video_tasks[tid])
+
+        t = threading.Thread(
+            target=_poll_volcengine,
+            args=(task_id, _volcengine_task_base(provider.base_url), provider.api_key, effective_model, req.prompt, provider.id),
+            daemon=True,
+        )
+        t.start()
     else:
         # ── Agnes: 后台轮询线程 ──
         def _poll_agnes(vid, tid, base, key):

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -72,6 +72,7 @@ def get_video_model_spec(model_name: str):
         ("wan2", "wan2"),
         ("wan_", "wan2"),
         ("hunyuan", "hunyuan"),
+        ("doubao", "seedance"),   # doubao-seedance 系列
         ("seedance", "seedance"),
         ("agnes", "agnes"),
     ]
@@ -332,7 +333,7 @@ async def _http_post_with_retry(url, headers, payload, *, timeout=120.0, max_ret
             except Exception:
                 pass
             raise httpx.HTTPStatusError(
-                f"{e.response.status_code} {e.response.reason_phrase} | Response: {body_text}",
+                f"{e.response.status_code} {e.response.reason_phrase} | Response: {translate_upstream_error(body_text)}",
                 request=e.request, response=e.response
             ) from e
         except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout) as e:
@@ -862,27 +863,52 @@ async def enhance_prompt_with_llm_detailed(prompt: str, llm_provider_id: str = N
 # ──────────────────────────────────────────────────────────────
 async def fetch_models_from_upstream(cfg: ProviderConfig) -> List[str]:
     """
-    根据 Provider 的 URL + API Key 调用上游接口获取可用模型列表
-    返回模型 ID 列表
-    """
-    protocol = _detect_protocol(cfg)
+    根据 Provider 配置从上游获取可用模型列表。
 
+    优先使用用户显式设置的 endpoint_type；为 auto 时按 URL 自动识别。
+    任何网络/协议失败都会如实抛出错误，**绝不返回伪造的模型列表**。
+    （火山方舟 Agent Plan 没有公开的模型列表 API，返回官方文档候选名，
+     这些候选名仅表示「可能可用」，真实可用性需在生成时验证。）
+    """
     if not cfg.api_key:
         raise ValueError("API Key 未配置")
     if not cfg.base_url:
         raise ValueError("Base URL 未配置")
 
-    try:
-        if protocol == "gemini":
-            return await _fetch_gemini_models(cfg)
-        elif protocol == "qwen":
-            return await _fetch_qwen_models(cfg)
-        else:
-            return await _fetch_openai_models(cfg)
-    except Exception as e:
-        print(f"[fetch-models] {cfg.name} 拉取失败: {e}")
-        # 返回 fallback 列表而不是直接报错
-        return _get_fallback_models(cfg, protocol)
+    # 1) 确定端点类型（显式优先）
+    et = (cfg.endpoint_type or "auto").strip().lower()
+    if et in ("auto", ""):
+        et = _detect_protocol(cfg)
+
+    # 2) 火山方舟 Agent Plan：无模型列表 API，返回官方候选名
+    if et == "volc_ark_plan":
+        return _volcengine_plan_candidate_models(cfg)
+
+    # 3) 标准 Ark / OpenAI 兼容 / Gemini / Qwen / Agnes：真实拉取，失败即报错
+    if et == "gemini":
+        return await _fetch_gemini_models(cfg)
+    if et == "qwen":
+        return await _fetch_qwen_models(cfg)
+    # volc_ark / openai / agnes 统一走 OpenAI 兼容 GET /v1/models
+    return await _fetch_openai_models(cfg)
+
+
+def _volcengine_plan_candidate_models(cfg: ProviderConfig) -> List[str]:
+    """火山方舟 Agent Plan 无模型列表 API，返回官方文档中的候选模型名。
+
+    仅为「可能可用」的候选，真实可用性需在生成时验证
+    （Small 套餐不支持视频生成，需 Medium 及以上套餐）。
+    """
+    if cfg.type == "video":
+        return [
+            "doubao-seedance-2.0",
+            "doubao-seedance-2.0-fast",
+            "doubao-seedance-2.0-mini",
+            "doubao-seedance-1.5-pro",
+        ]
+    if cfg.type == "image":
+        return ["doubao-seedream-5.0-lite"]
+    return []
 
 
 async def _fetch_openai_models(cfg: ProviderConfig) -> List[str]:
@@ -1020,6 +1046,50 @@ async def _fetch_qwen_models(cfg: ProviderConfig) -> List[str]:
         ]
 
 
+def translate_upstream_error(raw: str) -> str:
+    """将上游模型 API 常见的英文错误翻译成易懂的中文提示。
+
+    无法识别时原样返回，绝不吞掉原始信息（符合「错误要诚实、可懂」原则）。
+    """
+    if not raw:
+        return raw
+    s = raw.strip()
+    low = s.lower()
+
+    rules = [
+        ("does not support image input",
+         "当前模型不支持图片输入。请改用支持图生视频(I2V)/图生图的模型，或去掉图片只用文字生成。"),
+        ("image input",
+         "当前模型不支持图片输入。请改用支持图片的模型，或去掉参考图。"),
+        ("modelnotopen",
+         "该模型尚未在火山方舟控制台开通。请到方舟控制台「模型管理」中开通该模型服务后再试。"),
+        ("unsupportedmodel",
+         "该模型不被当前套餐/端点支持。请确认模型名称正确，且已在对应套餐或控制台开通。"),
+        ("invalidendpointormodel",
+         "模型或端点不存在/无访问权限。请确认模型名称正确，且账户已开通该模型。"),
+        ("authenticationerror",
+         "API Key 无效或无权限。请检查 Key 是否正确、是否复制完整。"),
+        ("invalidapikey",
+         "API Key 无效。请检查 Key 是否正确。"),
+        ("insufficient",
+         "账户余额不足或配额不足。请充值或提升套餐后重试。"),
+        ("quota",
+         "配额不足或已超限。请稍后重试或提升套餐。"),
+        ("rate limit",
+         "请求过于频繁，触发限流。请稍等片刻再试。"),
+        ("ratelimit",
+         "请求过于频繁，触发限流。请稍等片刻再试。"),
+        ("not found",
+         "请求的资源/模型不存在。请检查模型名称或端点。"),
+        ("timeout",
+         "上游响应超时。请稍后重试。"),
+    ]
+    for key, zh in rules:
+        if key in low:
+            return f"{zh}（原始信息：{s[:200]}）"
+    return s
+
+
 def _get_fallback_models(cfg: ProviderConfig, protocol: str) -> List[str]:
     """
     当上游 API 拉取失败时，返回该协议的常用模型列表
@@ -1027,6 +1097,9 @@ def _get_fallback_models(cfg: ProviderConfig, protocol: str) -> List[str]:
     """
     if cfg.type == "video":
         return [
+            "doubao-seedance-2.0",
+            "doubao-seedance-2.0-fast",
+            "doubao-seedance-1.5-pro",
             "veo-3-1-generate-preview",
             "veo-3-1-fast-generate-preview",
             "veo-3-0-generate-001",

--- a/release-notes-v2.3.1-zh.md
+++ b/release-notes-v2.3.1-zh.md
@@ -1,0 +1,64 @@
+- **Windows**: 双击 `GenBox.exe` 启动（建议先运行 `check_env.py` 检查环境）
+- **macOS**: 解压后运行 `./GenBox-macOS`（需先执行 `xattr -c GenBox-macOS` 去除隔离属性）
+- **Linux**: 解压后运行 `./GenBox-Linux-x64`
+
+### 快速开始
+
+1. 确保已安装 Python 3.10+
+2. 下载对应平台压缩包
+3. 解压并运行：
+   ```bash
+   # Windows
+   GenBox.exe
+
+   # macOS/Linux
+   ./GenBox-macOS  # 或 ./GenBox-Linux-x64
+   ```
+
+### 环境配置
+
+首次运行进入**交互式配置向导**：
+- 选择运行模式：本地开发 / VPS 生产 / Docker
+- 配置 API Key（支持 OpenAI、Claude、Gemini 等 13 家厂商）
+- 可选代理配置
+
+### 更新日志 v2.3.1
+
+**供应商配置稳健性 & 端点协议类型**
+- 新增显式 `endpoint_type` 选择（auto / openai / gemini / qwen / agnes / volc_ark_plan / volc_ark），可手动指定协议，避免自动识别误判
+- 移除火山方舟硬编码假模型列表：`volc_ark_plan` 现在只返回官方候选模型（doubao-seedance 系列），不再伪造可用模型
+- 模型拉取失败时如实报错，不再静默返回「推荐列表」（假成功）
+- 视频生成路由现在尊重显式 `endpoint_type`
+
+**上游错误中文化**
+- 新增 `translate_upstream_error`：将上游常见英文错误翻译为中文显示，如 `does not support image input`（不支持图片输入）、`ModelNotOpen`（模型未开通）、`UnsupportedModel`（模型不支持）、鉴权失败、余额/配额不足、限流、超时等，同时保留原始信息便于排查
+
+### 系统要求
+
+- Python 3.10 或更高
+- 无需安装依赖（exe 为自包含）
+
+### 已知问题
+
+- Windows 杀毒软件可能误报（PyInstaller 常见问题）
+- macOS 首次运行需 `xattr -c` 去除隔离
+- Linux GUI 模式需要 `libgl1` 依赖
+- `updater.CURRENT_VERSION` 当前为 `2.2.0`，打正式发布时建议同步改为 `2.3.1`
+
+### 相关链接
+
+- [GitHub 仓库](https://github.com/liwei9745/GenBox)
+- [Issue 跟踪](https://github.com/liwei9745/GenBox/issues)
+- [配置文档](https://github.com/liwei9745/GenBox/blob/main/README.md)
+
+### 重置管理员密钥
+
+删除 `config/settings.yaml` 并重启服务，首次运行向导会提示重新设置：
+
+```bash
+# Windows
+del config\settings.yaml
+
+# macOS/Linux
+rm config/settings.yaml
+```

--- a/release-notes-v2.3.1.md
+++ b/release-notes-v2.3.1.md
@@ -1,0 +1,64 @@
+- **Windows**: Double-click `GenBox.exe` to start (recommended to run `check_env.py` first to check environment)
+- **macOS**: After extracting, run `./GenBox-macOS` (need to run `xattr -c GenBox-macOS` to remove quarantine)
+- **Linux**: After extracting, run `./GenBox-Linux-x64`
+
+### Quick Start
+
+1. Ensure Python 3.10+ is installed
+2. Download the zip package for your platform
+3. Extract and run:
+   ```bash
+   # Windows
+   GenBox.exe
+
+   # macOS/Linux
+   ./GenBox-macOS  # or ./GenBox-Linux-x64
+   ```
+
+### Environment Configuration
+
+First run will enter **interactive configuration wizard**:
+- Select runtime mode: Local dev / VPS production / Docker
+- Configure API Keys (supports 13 providers including OpenAI, Claude, Gemini, etc.)
+- Optional proxy configuration
+
+### Changelog v2.3.1
+
+**Provider Config Robustness & Endpoint Type**
+- Added explicit `endpoint_type` selector (auto / openai / gemini / qwen / agnes / volc_ark_plan / volc_ark) so users can pin the protocol instead of relying on URL heuristics
+- Removed the hardcoded Volcano model fallback: `volc_ark_plan` now only returns official candidate models (doubao-seedance series), no longer faking available models
+- Model fetching now reports real errors on failure instead of silently returning a "recommended" fake list
+- Video generation routing now honors the explicit `endpoint_type`
+
+**Localized Upstream Errors**
+- Added `translate_upstream_error`: common upstream English errors are now shown in Chinese — e.g. `does not support image input`, `ModelNotOpen`, `UnsupportedModel`, auth failures, insufficient balance/quota, rate limit, timeout — while preserving the original message for debugging
+
+### System Requirements
+
+- Python 3.10 or higher
+- No dependency installation required (exe is self-contained)
+
+### Known Issues
+
+- Windows antivirus may give false positives (common PyInstaller issue)
+- macOS first run requires `xattr -c` to remove quarantine
+- Linux requires `libgl1` dependency (GUI mode)
+- `updater.CURRENT_VERSION` is currently `2.2.0` and should be bumped to `2.3.1` when cutting the release
+
+### Related Links
+
+- [GitHub Repository](https://github.com/liwei9745/GenBox)
+- [Issue Tracker](https://github.com/liwei9745/GenBox/issues)
+- [Configuration Documentation](https://github.com/liwei9745/GenBox/blob/main/README.md)
+
+### Key Reset
+
+To reset admin key, delete `config/settings.yaml` and restart the service. First-run wizard will prompt for new setup:
+
+```bash
+# Windows
+del config\settings.yaml
+
+# macOS/Linux
+rm config/settings.yaml
+```

--- a/static/index.html
+++ b/static/index.html
@@ -774,6 +774,6 @@
   </div>
 </nav>
 
-<script src="/static/js/app-all.js?v=12"></script>
+<script src="/static/js/app-all.js?v=14"></script>
 </body>
 </html>

--- a/static/js/app-all.js
+++ b/static/js/app-all.js
@@ -3778,6 +3778,7 @@ function renderProviderEdit() {
     provsInGroup.forEach(function(p) {
       var idx = allProviders.indexOf(p);
       var isOpen = providerEditOpenIdx === idx;
+      var et = p.endpoint_type || 'auto';
       var modelOpts = '';
       if (p.models && p.models.length) {
         var filteredModels = filterModelsByType(p.models, p.type);
@@ -3831,6 +3832,21 @@ function renderProviderEdit() {
                 '<option value="video" ' + (p.type==='video'?'selected':'') + '>🎬 生视频</option>' +
                 '<option value="llm" ' + (p.type==='llm'?'selected':'') + '>🤖 LLM</option>' +
               '</select>' +
+            '</div>' +
+            // 端点协议类型
+            '<div style="margin-bottom:8px;">' +
+              '<div style="font-size:10px;color:var(--text-muted);margin-bottom:3px;">端点协议类型（auto = 按 URL 自动识别）</div>' +
+              '<select class="modal-input" style="width:100%;padding:6px 8px;font-size:11px;box-sizing:border-box;" id="endpoint_type_' + idx + '">' +
+                '<option value="auto" ' + (et==='auto'?'selected':'') + '>🔄 自动识别 (auto)</option>' +
+                '<option value="openai" ' + (et==='openai'?'selected':'') + '>OpenAI 兼容 (openai)</option>' +
+                '<option value="gemini" ' + (et==='gemini'?'selected':'') + '>Google Gemini</option>' +
+                '<option value="qwen" ' + (et==='qwen'?'selected':'') + '>阿里通义 Qwen</option>' +
+                '<option value="agnes" ' + (et==='agnes'?'selected':'') + '>Agnes AI</option>' +
+                '<option value="volc_ark_plan" ' + (et==='volc_ark_plan'?'selected':'') + '>火山方舟 Agent Plan</option>' +
+                '<option value="volc_ark" ' + (et==='volc_ark'?'selected':'') + '>火山方舟 标准 Ark</option>' +
+              '</select>' +
+              (et==='volc_ark_plan' && p.type==='video' ?
+                '<div style="font-size:9px;color:#f59e0b;margin-top:3px;">⚠️ Small 套餐不支持视频生成，需在 Medium 及以上套餐才能实际出视频</div>' : '') +
             '</div>' +
             // 看板显示名
             '<div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;">' +
@@ -3995,6 +4011,7 @@ function saveProvider(idx) {
     display_name: (document.getElementById('display_name_' + idx) || {value:''}).value,
     capabilities: capabilities,
     skip_proxy: document.getElementById('skip_proxy_' + idx) ? document.getElementById('skip_proxy_' + idx).checked : false,
+    endpoint_type: (document.getElementById('endpoint_type_' + idx) || {value:'auto'}).value,
     quality: '', extra: {}
   };
   _authFetch('/api/providers', {
@@ -4148,21 +4165,22 @@ function fetchModels(idx) {
   var typeVal = document.getElementById('type_' + idx).value;
   var colorVal = document.getElementById('color_' + idx).value;
   var enVal = document.getElementById('en_' + idx).checked;
+  var etVal = (document.getElementById('endpoint_type_' + idx) || {value:'auto'}).value;
 
   var btn = document.getElementById('fetchBtn_' + idx);
   var st  = document.getElementById('fetchStatus_' + idx);
   btn.disabled = true; btn.textContent = '...';
   st.textContent = '连接中...'; st.style.color = 'var(--text-muted)';
 
-  var tmp = { id:pid||'tmp', name:nameVal, type:typeVal, base_url:urlVal, api_key:keyVal, model:'', color:colorVal, enabled:enVal, models:[], quality:'', extra:{} };
+  var tmp = { id:pid||'tmp', name:nameVal, type:typeVal, base_url:urlVal, api_key:keyVal, model:'', color:colorVal, enabled:enVal, endpoint_type:etVal, models:[], quality:'', extra:{} };
 
     _authFetch('/api/providers', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(tmp)})
     .then(function(){ return _authFetch('/api/providers/fetch-models/' + pid); })
     .then(function(r){ return r.json(); })
     .then(function(data){
       if (data.success) {
-        st.textContent = '✅ 拉取成功 ' + data.count + ' 个模型' + (data.is_fallback ? ' (推荐列表)' : '');
-        st.style.color = '#22c3a5';
+        st.textContent = '✅ 拉取成功 ' + data.count + ' 个模型' + (data.message ? ' ' + data.message : '');
+        st.style.color = data.is_fallback ? '#f59e0b' : '#22c3a5';
         try { localStorage.setItem('igs_models_' + pid, JSON.stringify(data.models)); } catch(e){}
         loadProviders().then(function(){ renderProviderEdit(); });
       } else {
@@ -4785,9 +4803,17 @@ function filterModelsByType(models, providerType) {
     if (providerType === 'video') {
       // 生视频模型：包含 t2v, i2v, r2v, veo_, interpolation, video
       if (ml.indexOf('t2v') !== -1 || ml.indexOf('i2v') !== -1 || ml.indexOf('r2v') !== -1) return true;
-      if (ml.indexOf('veo_') !== -1) return true;
+      if (ml.indexOf('veo_') !== -1 || ml.indexOf('veo-') !== -1) return true;
       if (ml.indexOf('interpolation') !== -1) return true;
       if (ml.indexOf('video') !== -1) return true;
+      // 主流视频模型厂商关键词
+      if (ml.indexOf('seedance') !== -1 || ml.indexOf('doubao') !== -1) return true;
+      if (ml.indexOf('sora') !== -1) return true;
+      if (ml.indexOf('kling') !== -1) return true;
+      if (ml.indexOf('hailuo') !== -1 || ml.indexOf('minimax') !== -1) return true;
+      if (ml.indexOf('wanx') !== -1 || ml.indexOf('wan2') !== -1) return true;
+      if (ml.indexOf('hunyuan') !== -1) return true;
+      if (ml.indexOf('gen-3') !== -1 || ml.indexOf('gen3') !== -1) return true;
       return false;
     }
     if (providerType === 'llm') {
@@ -4824,6 +4850,18 @@ function groupVideoModels(models) {
       if (ml.indexOf('veo_3') !== -1) cat = 'Veo 3.x 文生视频 (T2V)';
       else if (ml.indexOf('veo_2') !== -1) cat = 'Veo 2.x 文生视频 (T2V)';
       else cat = '文生视频 (T2V)';
+    } else if (ml.indexOf('seedance') !== -1 || ml.indexOf('doubao') !== -1) {
+      cat = '豆包 Seedance (火山方舟)';
+    } else if (ml.indexOf('kling') !== -1) {
+      cat = '可灵 Kling';
+    } else if (ml.indexOf('hailuo') !== -1 || ml.indexOf('minimax') !== -1) {
+      cat = '海螺 Hailuo (MiniMax)';
+    } else if (ml.indexOf('wanx') !== -1 || ml.indexOf('wan2') !== -1) {
+      cat = '通义万相 Wan';
+    } else if (ml.indexOf('hunyuan') !== -1) {
+      cat = '混元 Hunyuan';
+    } else if (ml.indexOf('sora') !== -1) {
+      cat = 'OpenAI Sora';
     } else {
       cat = '其他';
     }

--- a/updater.py
+++ b/updater.py
@@ -37,7 +37,7 @@ GITHUB_MIRRORS = [
 ]
 
 # 当前版本
-CURRENT_VERSION = "2.2.0"
+CURRENT_VERSION = "2.3.1"
 
 
 class UpdateType(Enum):


### PR DESCRIPTION
## 变更内容

### 供应商配置稳健性 & 端点协议类型
- 新增显式 \endpoint_type\ 选择（auto / openai / gemini / qwen / agnes / volc_ark_plan / volc_ark），可手动指定协议，避免自动识别误判
- 移除火山方舟硬编码假模型列表：\olc_ark_plan\ 仅返回官方候选模型（doubao-seedance 系列），不再伪造可用模型
- 模型拉取失败如实报错，不再静默返回「推荐列表」（假成功）
- 视频生成路由尊重显式 \endpoint_type\

### 上游错误中文化
- 新增 \	ranslate_upstream_error\：将上游常见英文错误翻译为中文显示（does not support image input / ModelNotOpen / UnsupportedModel / 鉴权失败 / 余额不足 / 限流 / 超时等），保留原始信息便于排查

### 其他
- 更新说明 release-notes-v2.3.1(.md/-zh.md)
- 同步 \updater.CURRENT_VERSION\ 为 2.3.1

## 测试
- 实测 Agent Plan 拉取返回 4 个官方候选模型，而非伪造列表
- 不可达 URL 拉取返回 \success:false\ 错误（不再假成功）
- 视频生成上游错误（ModelNotOpen 等）已验证返回中文提示