### PR TITLE
ci: 添加 Docker Compose 一键部署包

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,13 @@ jobs:
           cp README.md artifacts/release-linux/
           cd artifacts/release-linux && zip -r ../${{ env.APP_NAME }}-Linux-x64.zip .
 
+      - name: Package Docker Compose release
+        run: |
+          mkdir -p artifacts/release-docker
+          cp docker-compose.yml artifacts/release-docker/
+          cp .env.example artifacts/release-docker/.env
+          cd artifacts/release-docker && zip -r ../${{ env.APP_NAME }}-Docker-Compose.zip .
+
       - name: Select release notes
         id: rn
         shell: bash
@@ -211,7 +218,8 @@ jobs:
           gh release upload "${{ github.ref_name }}" \
             "artifacts/${{ env.APP_NAME }}-Windows.zip" \
             "artifacts/${{ env.APP_NAME }}-macOS.zip" \
-            "artifacts/${{ env.APP_NAME }}-Linux-x64.zip"
+            "artifacts/${{ env.APP_NAME }}-Linux-x64.zip" \
+            "artifacts/${{ env.APP_NAME }}-Docker-Compose.zip"
           
           # Upload standalone executables (for advanced users)
           gh release upload "${{ github.ref_name }}" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.8"
-
 services:
   genbox:
-    build: .
+    image: ${GENBOX_IMAGE:-ghcr.io/liwei9745/genbox:latest}
     container_name: genbox
     ports:
       - "8891:8891"


### PR DESCRIPTION
## 变更内容

- 将 `docker-compose.yml` 从本地构建改为默认拉取 GHCR 镜像
- 发布新版本时自动生成 `GenBox-Docker-Compose.zip`
- 部署包包含：
  - `docker-compose.yml`
  - 已重命名为 `.env` 的环境配置模板
- 用户解压并配置 `.env` 后，可直接运行：

```bash
docker compose up -d
```